### PR TITLE
Add specs/model_spec.md and enrich vgg11.py as agent reference material

### DIFF
--- a/specs/model_spec.md
+++ b/specs/model_spec.md
@@ -1,0 +1,219 @@
+# Hyrax Model Spec
+
+This document is the authoritative reference for converting a PyTorch model to be
+Hyrax-compatible. It is written for coding agents. Read it in full before modifying
+or generating any model code.
+
+---
+
+## 1. Repository Layout
+
+Place model files and configuration in the following locations:
+
+```
+src/<package>/
+    models/
+        <model_name>.py      # @hyrax_model decorated nn.Module subclass
+    default_config.toml      # default hyperparameters for all models and datasets
+    __init__.py
+```
+
+Reference implementation: `src/external_hyrax_example/models/vgg11.py`
+
+---
+
+## 2. `@hyrax_model` Decorator
+
+```python
+from hyrax.models.model_registry import hyrax_model
+
+@hyrax_model
+class MyModel(nn.Module):
+    ...
+```
+
+- Required on every model class.
+- Registers the class in Hyrax's model registry so it can be loaded by its
+  fully-qualified dotted path, e.g. `"mypkg.models.mymodel.MyModel"`.
+- Without it, `h.set_config("model.name", "...")` will fail at runtime.
+
+---
+
+## 3. Constructor: `__init__(self, config, data_sample=None)`
+
+Required signature:
+
+```python
+def __init__(self, config, data_sample=None):
+    super().__init__()
+```
+
+### `config`
+
+- Nested `dict` populated from `default_config.toml` plus any runtime overrides.
+- Access model hyperparameters via `config["<package>"]["<ClassName>"]["<param>"]`.
+- Example: `config["mypkg"]["MyModel"]["num_classes"]`
+
+### `data_sample`
+
+- A batch tuple `(images, ...)` where `images` has shape `(N, C, H, W)`.
+- Use `data_sample[0].shape` to infer input dimensions dynamically instead of
+  hard-coding them.
+- Raise `ValueError` if the model requires `data_sample` but receives `None`.
+
+### `default_config.toml` entry
+
+Add a TOML section for every configurable hyperparameter:
+
+```toml
+[mypkg.MyModel]
+num_classes = 10
+dropout = 0.5
+```
+
+Runtime override syntax:
+
+```python
+h.set_config("mypkg.MyModel.num_classes", 5)
+```
+
+---
+
+## 4. Required Batch Methods
+
+Each method implements only the **innermost logic** of its respective loop.
+Hyrax owns the outer loop, gradient context (`torch.no_grad()` for val/test/infer),
+and device placement.
+
+| Method | Hyrax caller | Returns |
+|---|---|---|
+| `forward(batch: tuple) -> Tensor` | all batch methods | raw model output |
+| `train_batch(batch) -> dict` | `h.train()` | `{"loss": float, ...}` |
+| `validate_batch(batch) -> dict` | `h.train()` (val phase) | `{"loss": float, ...}` |
+| `test_batch(batch) -> dict` | `h.test()` | `{"loss": float, ...}` |
+| `infer_batch(batch) -> Tensor` | `h.infer()` | raw model output (same as `forward`) |
+
+### `forward`
+
+Standard PyTorch forward pass. Called internally by all batch methods.
+
+```python
+def forward(self, batch: tuple) -> torch.Tensor:
+    x, _ = batch
+    return self.net(x)
+```
+
+### `train_batch`
+
+Must zero gradients, compute loss, back-propagate, and step the optimizer.
+`self.optimizer` and `self.criterion` are injected by Hyrax before training starts.
+Hyrax provides configurable built-in PyTorch optimizers and loss functions by default;
+the model may supply its own if needed.
+
+```python
+def train_batch(self, batch):
+    _, labels = batch
+    self.optimizer.zero_grad()
+    loss = self.criterion(self(batch), labels)
+    loss.backward()
+    self.optimizer.step()
+    return {"loss": loss.item()}
+```
+
+### `validate_batch` and `test_batch`
+
+Same as `train_batch` but without the gradient update. Do **not** call
+`loss.backward()` or `self.optimizer.step()`.
+
+```python
+def validate_batch(self, batch):
+    _, labels = batch
+    return {"loss": self.criterion(self(batch), labels).item()}
+
+def test_batch(self, batch):
+    _, labels = batch
+    return {"loss": self.criterion(self(batch), labels).item()}
+```
+
+### `infer_batch`
+
+No loss computation. Return raw model output.
+
+```python
+def infer_batch(self, batch):
+    return self(batch)
+```
+
+---
+
+## 5. `prepare_inputs` Static Method
+
+Hyrax calls this before every batch to convert the raw data dictionary into
+the tuple format the batch methods expect.
+
+```python
+@staticmethod
+def prepare_inputs(data_dict):
+    if "data" not in data_dict:
+        raise RuntimeError("Unable to find `data` key in data_dict")
+    data = data_dict["data"]
+    label = data.get("label", None)
+    return (data["image"], label)
+```
+
+- Must be a `@staticmethod`.
+- Input structure: `{"data": {"image": Tensor, "label": Tensor, ...}}`.
+- `"label"` is absent during inference; always use `.get("label", None)`.
+- Best practice: raise `RuntimeError` when the `"data"` key is missing.
+- Return value must match the tuple signature consumed by `forward`.
+
+---
+
+## 6. Wiring a Model into Hyrax
+
+```python
+from hyrax import Hyrax
+
+h = Hyrax()
+h.set_config("model.name", "mypkg.models.mymodel.MyModel")
+h.set_config("data_request", {
+    "train": {
+        "data": {
+            "dataset_class": "mypkg.datasets.mydataset.MyDataset",
+            "data_location": "./data/my_data",
+            "fields": ["image", "label"],
+            "primary_id_field": "object_id",
+            "split_fraction": 0.8,
+        },
+    },
+})
+
+model = h.train()
+results = h.infer()
+```
+
+---
+
+## 7. Common Pitfalls
+
+- **Hard-coding input shape**: always infer channels from `data_sample[0].shape`
+  so the model works across datasets with different channel counts.
+- **Missing `@hyrax_model`**: the model will not be discoverable by dotted path
+  and `h.train()` will raise an error.
+- **Wrong config namespace**: the top-level key must match the Python package name
+  (e.g. `config["mypkg"]`, not `config["MyModel"]`).
+- **Backward pass in `validate_batch` / `test_batch`**: these run inside
+  `torch.no_grad()`; calling `loss.backward()` will raise a runtime error.
+- **Defining `self.optimizer` / `self.criterion` in `__init__`**: Hyrax
+  overwrites these attributes before training begins. Initialising them in the
+  constructor bypasses Hyrax's built-in optimizer and loss configurability.
+
+---
+
+## 8. Reference Files
+
+| File | Purpose |
+|---|---|
+| `src/external_hyrax_example/models/vgg11.py` | Complete, annotated working example (read this first) |
+| `src/external_hyrax_example/default_config.toml` | TOML config pattern |
+| `docs/pre_executed/model_usage_example.ipynb` | End-to-end usage walkthrough |

--- a/src/external_hyrax_example/models/vgg11.py
+++ b/src/external_hyrax_example/models/vgg11.py
@@ -46,6 +46,9 @@ class VGG11(nn.Module):
 
         Raises:
             ValueError: If ``data_sample`` is not provided.
+
+        See Also:
+            https://docs.pytorch.org/vision/main/models/generated/torchvision.models.vgg11.html#torchvision.models.vgg11
         """
         super().__init__()
         if data_sample is None:

--- a/src/external_hyrax_example/models/vgg11.py
+++ b/src/external_hyrax_example/models/vgg11.py
@@ -30,16 +30,16 @@ class VGG11(nn.Module):
     """
 
     def __init__(self, config, data_sample=None):
-        """Initialise the VGG11 architecture.
+        """Initialize the VGG11 architecture.
 
         Args:
             config: Nested configuration dictionary populated from the package's
                 ``default_config.toml`` and any runtime overrides set via
                 ``hyrax.Hyrax.set_config``.  Model hyperparameters are read from
                 ``config["external_hyrax_example"]["VGG11"]``.
-            data_sample: A single batch tuple ``(images, labels)`` produced by
-                the dataset's ``prepare_inputs`` method.  The first element must
-                be a float tensor of shape ``(N, C, H, W)``.  The channel count
+            data_sample: A single batch tuple ``(images, labels)`` prepared for
+                the model by Hyrax via ``prepare_inputs``. The first element must
+                be a float tensor of shape ``(N, C, H, W)``. The channel count
                 ``C`` is used to build the first convolutional layer so that the
                 model adapts to the dataset without hard-coding input dimensions.
                 Raises ``ValueError`` if ``None``.

--- a/src/external_hyrax_example/models/vgg11.py
+++ b/src/external_hyrax_example/models/vgg11.py
@@ -11,13 +11,42 @@ cfgs = {
 
 @hyrax_model
 class VGG11(nn.Module):
-    """Copy of the PyTorch VGG11 model for testing and demonstration
-    purposes.
-    https://docs.pytorch.org/vision/main/models/generated/torchvision.models.vgg11.html#torchvision.models.vgg11
+    """VGG11 CNN — canonical example of a Hyrax-compatible external model.
+
+    This class demonstrates every requirement for integrating a PyTorch model
+    with the Hyrax framework:
+
+    1. Decorated with ``@hyrax_model`` so Hyrax can discover this class by its
+       fully-qualified dotted path (e.g. ``"external_hyrax_example.models.vgg11.VGG11"``).
+    2. Constructor accepts ``config`` and ``data_sample`` (see ``__init__``).
+    3. Implements the five Hyrax batch methods: ``forward``, ``train_batch``,
+       ``validate_batch``, ``test_batch``, and ``infer_batch``.
+    4. Implements the static ``prepare_inputs`` method to convert the raw
+       data dictionary supplied by Hyrax into the tuple format the model expects.
+    5. Reads all hyperparameters from ``config`` using the hierarchical key
+       ``config["<package>"]["<ClassName>"]["<param>"]``.
+
+    Reference: https://docs.pytorch.org/vision/main/models/generated/torchvision.models.vgg11.html
     """
 
     def __init__(self, config, data_sample=None):
-        """Basic initialization with architecture definition"""
+        """Initialise the VGG11 architecture.
+
+        Args:
+            config: Nested configuration dictionary populated from the package's
+                ``default_config.toml`` and any runtime overrides set via
+                ``hyrax.Hyrax.set_config``.  Model hyperparameters are read from
+                ``config["external_hyrax_example"]["VGG11"]``.
+            data_sample: A single batch tuple ``(images, labels)`` produced by
+                the dataset's ``prepare_inputs`` method.  The first element must
+                be a float tensor of shape ``(N, C, H, W)``.  The channel count
+                ``C`` is used to build the first convolutional layer so that the
+                model adapts to the dataset without hard-coding input dimensions.
+                Raises ``ValueError`` if ``None``.
+
+        Raises:
+            ValueError: If ``data_sample`` is not provided.
+        """
         super().__init__()
         if data_sample is None:
             raise ValueError(
@@ -25,7 +54,8 @@ class VGG11(nn.Module):
                 "so that input channel dimensions can be inferred, but received None."
             )
 
-        # This model expects that the first element of the data sample is a batch of images.
+        # Infer input channels from the sample rather than hard-coding them.
+        # data_sample[0] is a batch of images with shape (N, C, H, W).
         image_sample = data_sample[0]
         batch_size, self.in_channels, width, height = image_sample.shape
 
@@ -64,7 +94,17 @@ class VGG11(nn.Module):
         return nn.Sequential(*layers)
 
     def forward(self, batch: tuple) -> torch.Tensor:
-        """The innermost logic in the forward pass"""
+        """Run the model's core forward pass.
+
+        Args:
+            batch: Tuple ``(images, labels)`` where ``images`` is a float
+                tensor of shape ``(N, C, H, W)``.  ``labels`` is ignored here
+                but included so that ``batch`` can be passed directly from
+                ``train_batch`` / ``validate_batch`` without unpacking.
+
+        Returns:
+            Class logits of shape ``(N, num_classes)``.
+        """
         x, _ = batch
         x = self.features(x)
         x = self.avgpool(x)
@@ -73,11 +113,36 @@ class VGG11(nn.Module):
         return x
 
     def infer_batch(self, batch):
-        """The innermost logic in the inference loop"""
+        """Innermost logic of the Hyrax inference loop.
+
+        Called once per batch by ``hyrax.Hyrax.infer()``.  No loss is computed.
+
+        Args:
+            batch: Tuple ``(images, labels)`` as produced by ``prepare_inputs``.
+
+        Returns:
+            Class logits tensor of shape ``(N, num_classes)``.
+        """
         return self(batch)
 
     def train_batch(self, batch):
-        """The innermost logic in the training loop"""
+        """Innermost logic of the Hyrax training loop.
+
+        Called once per batch by ``hyrax.Hyrax.train()``.  Hyrax handles the
+        outer epoch loop, gradient context, and device placement.  This method
+        is responsible only for the per-batch forward pass, loss computation,
+        and parameter update.
+
+        ``self.optimizer`` and ``self.criterion`` are injected by Hyrax before
+        training starts.  Hyrax provides configurable built-in PyTorch optimizers
+        and loss functions by default; the model can override them if needed.
+
+        Args:
+            batch: Tuple ``(images, labels)`` as produced by ``prepare_inputs``.
+
+        Returns:
+            Dict of scalar metrics, e.g. ``{"loss": 0.312}``.
+        """
         _, labels = batch
         self.optimizer.zero_grad()
         outputs = self(batch)
@@ -87,14 +152,35 @@ class VGG11(nn.Module):
         return {"loss": loss.item()}
 
     def validate_batch(self, batch):
-        """The innermost logic in the validation loop"""
+        """Innermost logic of the Hyrax validation loop.
+
+        Called once per batch during the validation phase of ``hyrax.Hyrax.train()``.
+        Hyrax runs this inside a ``torch.no_grad()`` context, so no backward pass
+        is needed or expected.
+
+        Args:
+            batch: Tuple ``(images, labels)`` as produced by ``prepare_inputs``.
+
+        Returns:
+            Dict of scalar metrics, e.g. ``{"loss": 0.298}``.
+        """
         _, labels = batch
         outputs = self(batch)
         loss = self.criterion(outputs, labels)
         return {"loss": loss.item()}
 
     def test_batch(self, batch):
-        """The innermost logic in the testing loop"""
+        """Innermost logic of the Hyrax test loop.
+
+        Called once per batch by ``hyrax.Hyrax.test()``.  Like ``validate_batch``,
+        this runs inside a ``torch.no_grad()`` context.
+
+        Args:
+            batch: Tuple ``(images, labels)`` as produced by ``prepare_inputs``.
+
+        Returns:
+            Dict of scalar metrics, e.g. ``{"loss": 0.301}``.
+        """
         _, labels = batch
         outputs = self(batch)
         loss = self.criterion(outputs, labels)
@@ -102,8 +188,32 @@ class VGG11(nn.Module):
 
     @staticmethod
     def prepare_inputs(data_dict):
-        """Method that converts the data in dictionary into the form the model expects"""
+        """Convert a Hyrax data dictionary into the tuple format the model expects.
 
+        Hyrax calls this method before passing data to ``train_batch``,
+        ``validate_batch``, ``test_batch``, and ``infer_batch``.  The returned
+        tuple must match the signature expected by ``forward``.
+
+        The incoming ``data_dict`` has the structure::
+
+            {
+                "data": {
+                    "image": <tensor>,   # always present
+                    "label": <tensor>,   # present during train/val/test, absent during infer
+                    ...                  # any other fields declared in data_request
+                }
+            }
+
+        Args:
+            data_dict: Dictionary produced by the dataset class and Hyrax's
+                data loader.  Must contain a ``"data"`` key.
+
+        Returns:
+            Tuple ``(image, label)`` where ``label`` is ``None`` if not present.
+
+        Raises:
+            RuntimeError: If ``data_dict`` does not contain a ``"data"`` key.
+        """
         if "data" not in data_dict:
             raise RuntimeError("Unable to find `data` key in data_dict")
 


### PR DESCRIPTION
- Create specs/ directory with model_spec.md: a dense, agent-targeted
  reference covering the @hyrax_model decorator, constructor contract,
  all five batch methods, prepare_inputs, TOML config, Hyrax wiring,
  and common pitfalls
- Expand vgg11.py class/method docstrings so the file serves as the
  canonical annotated example agents are directed to read

https://claude.ai/code/session_01535J3bEqioGhVTVR7sdEN6